### PR TITLE
(Hopefully) performance improvements

### DIFF
--- a/backend/model/label_data.rb
+++ b/backend/model/label_data.rb
@@ -6,24 +6,89 @@ class LabelData
 
   def initialize(uris)
     @uris = uris
-    @labels = []
-
-    build_label_data
+    @labels = build_label_data
   end
+
 
   def build_label_data
     ids = @uris.map {|uri| JSONModel(:top_container).id_for(uri)}
-    top_containers = TopContainer.sequel_to_jsonmodel(TopContainer.filter(:id => ids).all).map{|tc| tc.to_hash(:trusted)}
-    resolved_top_containers = URIResolver.resolve_references(top_containers, ['container_locations', 'linked_records'], {})
+
+    # Pre-store the links between our top containers and the archival objects they link to
+    top_container_to_ao_links = calculate_top_container_linkages(ids)
+
+    # Eagerly load all of the AO and Top Containers we'll be working with
+    load_top_containers(top_container_to_ao_links.keys)
+    load_archival_objects(top_container_to_ao_links.values.flatten.uniq)
+
+    # Finally, walk over our AO/top container pairs and create a label for each
     labels = []
-    resolved_top_containers.each do |label|
-      label['linked_records'].each do |ao|
-        if ao['_resolved']['other_level'] && ao['_resolved']['other_level'].strip.downcase == 'box'
-          labels << label.merge({'archival_object' => ao}).reject{|k| k == 'linked_records'}
-        end
+    top_container_to_ao_links.each do |top_container_id, ao_ids|
+      ao_ids.each do |ao_id|
+        ao = fetch_archival_object(ao_id)
+        tc = fetch_top_container(top_container_id)
+        series = series_title_for(ao_id)
+
+        labels << tc.merge({'archival_object' => {'ref' => ao['uri'], 'series' => series, '_resolved' => ao}})
       end
     end
-    @labels = labels
+
+    labels
+  end
+
+
+  private
+
+  # Returns a hash like {123 => 456}, meaning "Top Container 123 links to Archival Object 456"
+  # Only includes the links to Archival Object box records
+  def calculate_top_container_linkages(ids)
+    result = {}
+
+    TopContainer.linked_instance_ds.
+      join(:archival_object, :id => :instance__archival_object_id).
+      filter(:top_container__id => ids).
+      filter(:archival_object__other_level => 'box').
+      select(Sequel.as(:archival_object__id, :ao_id),
+             Sequel.as(:top_container__id, :top_container_id)).each do |row|
+
+      result[row[:top_container_id]] ||= []
+      result[row[:top_container_id]] << row[:ao_id]
+    end
+
+    result
+  end
+
+
+  def load_archival_objects(ids)
+    ao_list = ArchivalObject.filter(:id => ids).all
+
+    # Our JSONModel(:archival_object) records (keyed on ID)
+    @ao_json_records = Hash[ArchivalObject.sequel_to_jsonmodel(ao_list).map {|ao| [ao.id, ao.to_hash(:trusted)]}]
+
+    # And their series display strings
+    @ao_series_titles = Hash[ao_list.map {|ao| [ao.id, TopContainer.find_title_for(ao.series || ao)]}]
+  end
+
+
+  def load_top_containers(ids)
+    top_container_list = TopContainer.filter(:id => ids).all
+    top_container_json_records = Hash[TopContainer.sequel_to_jsonmodel(top_container_list).map {|tc| [tc.id, tc.to_hash(:trusted)]}]
+
+    @top_container_json_records = URIResolver.resolve_references(top_container_json_records, ['container_locations'], {})
+  end
+
+
+  def series_title_for(ao_id)
+    @ao_series_titles.fetch(ao_id)
+  end
+
+
+  def fetch_top_container(id)
+    @top_container_json_records.fetch(id)
+  end
+
+
+  def fetch_archival_object(id)
+    @ao_json_records.fetch(id)
   end
 
 end

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -149,11 +149,13 @@ class TopContainer < Sequel::Model(:top_container)
       json['long_display_string'] = obj.long_display_string
 
       obj.linked_archival_records.each do |archival_record|
-        json['linked_records'] ||= []
-        json['linked_records'] << {
-          'ref' => archival_record.uri,
-          'series' => find_title_for(archival_record.series)
-        }
+        if archival_record.respond_to?(:series) && archival_record.series
+          json['linked_records'] ||= []
+          json['linked_records'] << {
+            'ref' => archival_record.uri,
+            'series' => find_title_for(archival_record.series)
+          }
+        end
       end
 
       obj.series.each do |series|

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -148,16 +148,6 @@ class TopContainer < Sequel::Model(:top_container)
       json['display_string'] = obj.display_string
       json['long_display_string'] = obj.long_display_string
 
-      obj.linked_archival_records.each do |archival_record|
-        if archival_record.respond_to?(:series) && archival_record.series
-          json['linked_records'] ||= []
-          json['linked_records'] << {
-            'ref' => archival_record.uri,
-            'series' => find_title_for(archival_record.series)
-          }
-        end
-      end
-
       obj.series.each do |series|
         json['series'] ||= []
         json['series'] << {


### PR DESCRIPTION
Howdy,

Here's a pull request for your pull request :)  I had a go at moving some of the calculation logic out of the Top Container model (which is already a bit of a performance hotspot), and hopefully I've made the label generation a bit faster too.

I was worried about top containers because I tried benchmarking them via the indexer and saw:

```
 Prior to labels: Indexed 10171 records in 180 seconds
 After labels: Indexed 10171 records in 507 seconds
```

So the performance hit for resolving the linked archival objects was pretty large.  I've switched it to use a join to pull back the bits it needs and tried to group together the various queries as much as possible.  It looks to be working properly to me, but let me know if I messed anything up.
